### PR TITLE
feat: add cacheLocation settings, remove .eslintcache file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import type { Plugin } from 'vite';
 import { ESLint } from 'eslint';
 import { createFilter } from '@rollup/pluginutils';
@@ -18,6 +19,11 @@ export default function eslintPlugin(options: Options = {}): Plugin {
   };
   const opts = { ...defaultOptions, ...options };
   const eslint = new ESLint({
+    cacheLocation: path.resolve(
+      process.cwd(),
+      // maybe vite config cacheDir is better ?
+      './node_modules/.vite/vite-plugin-eslint',
+    ),
     cache: opts.cache,
     fix: opts.fix,
   });


### PR DESCRIPTION
there will be a `.eslintcache` at projectRoot, which we can hide it by `eslint.cacheLocation option` and vue-cli do that.

https://github.com/vuejs/vue-cli/blob/ae967f769817b2e6dba19a3c0d171be48f67f2a2/packages/%40vue/cli-plugin-eslint/index.js#L38