### PR TITLE
Add virtual dir to the exclude option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A single file, or array of files, to include when linting.
 ### `exclude`
 
 - Type: `string | RegExp | ReadonlyArray<string | RegExp>`
-- Default: `/node_modules/`
+- Default: `[/virtual:/, /node_modules/]`
 
 A single file, or array of files, to exclude when linting.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export default function eslintPlugin(rawOptions: Options = {}): Plugin {
       options = Object.assign<Options, Options>(
         {
           include: /\.(jsx?|tsx?|vue|svelte)$/,
-          exclude: /node_modules/,
+          exclude: [/virtual:/, /node_modules/],
           // Use vite cacheDir as default
           cacheLocation: resolve(config.cacheDir, '.eslintcache'),
           formatter: 'stylish',


### PR DESCRIPTION
This PR adds a new path to the `exclude` option, so Eslint does not try to include virtual directories

Issue: https://github.com/storybookjs/builder-vite/issues/367