### PR TITLE
fix: let eslint not to find config for virtual module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ export default function eslintPlugin(rawOptions: Options = {}): Plugin {
         fileCache.delete(filePath)
       }
 
-      if (!filter(filePath) || (await eslint.isPathIgnored(filePath)) || isVirtual) {
+      if (isVirtual || !filter(filePath) || (await eslint.isPathIgnored(filePath))) {
         return null
       }
 


### PR DESCRIPTION
fixes https://github.com/storybookjs/builder-vite/issues/367

eslint tries to find config on executing `isPathIgnored`, and it errors if the config file does not exist.

This PR suppresses to call eslint method in transforming virtual module.
