### PR TITLE
Add the `types` condition to the `package.json#exports`

### DIFF
--- a/index.d.mts
+++ b/index.d.mts
@@ -1,0 +1,4 @@
+import ns from './dist/index.js'
+
+export * from './dist/index.js'
+export default ns.default

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }

--- a/package.json
+++ b/package.json
@@ -9,13 +9,19 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "index.d.mts"
   ],
   "scripts": {
     "dev": "npm run build -- --watch ./src",


### PR DESCRIPTION
This is required for TypeScript to work with packages that have `exports` when using the new `moduleResolution: node16/nodenext/bundler` settings. When those are not used then TypeScript just ignores `package.json#exports` - but when you make it aware of `exports` by using those options then it requires the `types` to be included in `exports` and not as the top-level key of `package.json`