### PR TITLE
fix: remove unneeded warn log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,8 +60,6 @@ export default function eslintPlugin(rawOptions: Options = {}): Plugin {
         }
 
         if (options.lintOnStart && options.include) {
-          this.warn('LintOnStart is turned on, and it will check for all matching files.')
-
           const [error] = await to(
             checkModule(this, eslint, options.include, options, formatter, outputFixes)
           )


### PR DESCRIPTION
Since the `lintOnStart` option is `false` by default, the user _must_ have intentionally set this configuration option. So we don't need this warn lint clogging up the terminal when it's working as intended.