### PR TITLE
Add types for exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
For moduleResolution: 'Bundler'，cannot found types.
Add types in export will work fine.