### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Custom error formatter or the name of a built-in formatter.
 - Type: `boolean`
 - Default: `true`
 
-The warings found will be printed.
+The warnings found will be printed.
 
 ### `emitError`
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface Options extends ESLint.Options {
   exclude?: string | string[]
   /** Custom error formatter or the name of a built-in formatter */
   formatter?: string | ESLint.Formatter['format']
-  /** The warings found will be printed */
+  /** The warnings found will be printed */
   emitWarning?: boolean
   /** The errors found will be printed */
   emitError?: boolean


### PR DESCRIPTION
`warings` -> `warnings`